### PR TITLE
adds rms parser implementation, maturity tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ Useful repositories and articles related to developing software and analysis for
 | --- | --- | --- | --- |
 | [mangudai](https://github.com/mangudai/mangudai) | javascript | high | any |
 | [aoc-rms](https://github.com/happyleavesaoc/aoc-rms) | python | medium | any |
-| [rms-check](https://github.com/goto-bus-stop/rms-check) | rust | medium | any |
+| [rms-parser](https://gist.github.com/goto-bus-stop/cb59e5f0ae03ec12c3800f120c16eef3) | javascript | medium | aoc |
+| [rms-check](https://github.com/goto-bus-stop/rms-check) | rust | low | any |
 ### recs
 | Repository | Language | Maturity | Version |
 | --- | --- | --- | --- |
 | [aoc-mgz](https://github.com/happyleavesaoc/aoc-mgz) | python | high | up |
-| [recage](https://github.com/goto-bus-stop/recage) | javascript | medium | up |
+| [recage](https://github.com/goto-bus-stop/recage) | javascript | low | up |
 | [recanalyst](https://github.com/goto-bus-stop/recanalyst) | php | high | any |
 | [aoc-mgz-format](https://github.com/stefan-kolb/aoc-mgx-format) | ruby | low | aoc |
 ### voobly
@@ -42,12 +43,12 @@ Useful repositories and articles related to developing software and analysis for
 | Repository | Language | Maturity | Version |
 | --- | --- | --- | --- |
 | [genie-reverse](https://github.com/yvan-burrie/Genie-Reverse) | c++ | medium | aoc |
-| [genie-slp](https://github.com/goto-bus-stop/genie-slp) | javascript | medium | aoc |
-| [genie-drs](https://github.com/goto-bus-stop/genie-drs) | javascript | medium | aoc |
+| [genie-slp](https://github.com/goto-bus-stop/genie-slp) | javascript | high | aoc |
+| [genie-drs](https://github.com/goto-bus-stop/genie-drs) | javascript | high | aoc |
 ### scx
 | Repository | Language | Maturity | Version |
 | --- | --- | --- | --- |
-| [genie-scx](https://github.com/goto-bus-stop/genie-scx) | javascript | medium | aoc |
+| [genie-scx](https://github.com/goto-bus-stop/genie-scx) | javascript | low | aoc |
 | [agescx](https://github.com/dderevjanik/agescx) | python | medium | aoc |
 ## Articles
 - [Predicting Voobly Age of Empires 2 Matches](http://blog.macuyiko.com/post/2018/predicting-voobly-age-of-empires-2-matches.html)

--- a/data.yaml
+++ b/data.yaml
@@ -29,6 +29,12 @@ repositories:
     maturity: medium
     version: up
     url: https://github.com/goto-bus-stop/recage
+  - name: rms-parser
+    language: javascript
+    category: rms
+    maturity: medium
+    version: aoc
+    url: https://gist.github.com/goto-bus-stop/cb59e5f0ae03ec12c3800f120c16eef3
   - name: rms-check
     language: rust
     category: rms

--- a/data.yaml
+++ b/data.yaml
@@ -26,7 +26,7 @@ repositories:
   - name: recage
     language: javascript
     category: recs
-    maturity: medium
+    maturity: low
     version: up
     url: https://github.com/goto-bus-stop/recage
   - name: rms-parser
@@ -38,7 +38,7 @@ repositories:
   - name: rms-check
     language: rust
     category: rms
-    maturity: medium
+    maturity: low
     version: any
     url: https://github.com/goto-bus-stop/rms-check
   - name: recanalyst
@@ -104,19 +104,19 @@ repositories:
   - name: genie-scx
     language: javascript
     category: scx
-    maturity: medium
+    maturity: low
     version: aoc
     url: https://github.com/goto-bus-stop/genie-scx
   - name: genie-slp
     language: javascript
     category: genie
-    maturity: medium
+    maturity: high
     version: aoc
     url: https://github.com/goto-bus-stop/genie-slp
   - name: genie-drs
     language: javascript
     category: genie
-    maturity: medium
+    maturity: high
     version: aoc
     url: https://github.com/goto-bus-stop/genie-drs
   - name: agescx


### PR DESCRIPTION
As part of a private unfinished project to reimplement the AoC random map generator, I built a JS parser that is almost identical to the AoC implementation. The parser turns RMS source code into a bunch of objects describing the map generation, after having processed all if/else and start_random statements.

recage does not yet work and genie-scx is incomplete (I only use it to draw map layouts in https://genie-explorer.surge.sh/ so far), so i put their maturity down to low.
rms-check is still very new and largely untested so i also put it down to low.

genie-slp and genie-drs have been around for a few years now and are stable and reliable in my experience. genie-slp is incomplete in the sense that it will get an encoder at some point and may not support SLPs from AoE1 or the definitive editions, but it works well for AoC and HD. i've bumped both their maturities to high.