### PR TITLE
merge from downstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Useful repositories and articles related to developing software and analysis for
 | [run-aoe-rms](https://github.com/goto-bus-stop/run-aoe-rms) | javascript | low | up |
 | [aoe2stats](https://github.com/aocpip/aoe2stats) | javascript | high | any |
 | [aoc-headless](https://github.com/happyleavesaoc/aoc-headless) | python | low | up |
+| [openage](https://github.com/SFTtech/openage) | various | low | n/a |
 ### mod
 | Repository | Language | Maturity | Version |
 | --- | --- | --- | --- |


### PR DESCRIPTION
after merging this we can:

 - delete siegeengineers/aoc-dev-resources
 - transfer happyleavesaoc/aoc-dev-resources to siegeengineers org