### PR TITLE
Add aoc-ai-parser and an ai category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Useful repositories and articles related to developing software and analysis for
 | --- | --- | --- | --- |
 | [DyingServer](https://github.com/sdjnyty/DyingServer) | C# | low | various |
 | [dplobbyserver](https://github.com/goto-bus-stop/dplobbysystem) | pascal | low | aoc |
+### ai
+| Repository | Language | Maturity | Version |
+| --- | --- | --- | --- |
+| [aoc-ai-parser](https://github.com/FLWL/aoc-ai-parser) | python | low | aoc |
 ## APIs & Protocols
 - [Steam Browser Protocol](https://developer.valvesoftware.com/wiki/Steam_browser_protocol)
 - [Steam Web API](https://developer.valvesoftware.com/wiki/Steam_Web_API)

--- a/data.yaml
+++ b/data.yaml
@@ -209,6 +209,12 @@ repositories:
     maturity: low
     version: aoc
     url: https://github.com/goto-bus-stop/dplobbysystem
+  - name: aoc-ai-parser
+    language: python
+    category: ai
+    maturity: low
+    version: aoc
+    url: https://github.com/FLWL/aoc-ai-parser
 articles:
   - name: "Predicting Voobly Age of Empires 2 Matches"
     url: http://blog.macuyiko.com/post/2018/predicting-voobly-age-of-empires-2-matches.html


### PR DESCRIPTION
Request to add aoc-ai-parser to the list of dev resources.

I put it in a new category named 'ai', because I couldn't find an existing one that it would fit in - and also I think that in the future more AI related stuff is coming.